### PR TITLE
Json output formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ _A command line interface on Linux and Windows for running and managing requests
 
 ![Screenshot](cli.png)
 
+
 ## How it works
 
 Run `resty` with a .http-file as argument.
@@ -76,23 +77,27 @@ Example config file:
   "CurlCommand": "notcurl",
   "Editor": "edlin.exe",
   "ColorMode": true,
-  "InsecureSSL": true
+  "InsecureSSL": true,
+  "Formatters": {
+      "application/json": "jq"
+  }
 }
 ```
+
 Default values if settings are empty or not present:
 - CurlCommand = curl
 - Editor = `$EDITOR` (or `%EDITOR%`)
 - ColorMode = false
 - InsecureSSL = false (if true, the -k flag will be sent to curl)
+- Formatters is a map from mime-type to executable program, like `jq`,
+  that formats the response data. Note that the accept header must be
+  set for the request.
 
 
 ## Future
 
 Some ideas about possible improvements.
 
-- Add response formatters per header accept values.
-    - i.e if header has `accept: application/json` then use formatter
-      defined in config (like jq) to format the response.
 - Maybe replace curl command execution with home made implementation.
 
 /Calle

--- a/cli/config.go
+++ b/cli/config.go
@@ -17,15 +17,12 @@ const DefaultConfigFileName = ".resty.json"
 
 // Config holds the settings.
 type Config struct {
-	configFile  string // Config file path, set by application
-	CurlCommand string // Default "curl"
-	Editor      string // Default $EDITOR
-	ColorMode   bool   // TODO: implement - Default false, no color
-	InsecureSSL bool   // Default false
-
-	// TODO: Add config settings
-	// - add formatter per header accept types
-
+	configFile  string            // Config file path, set by application
+	CurlCommand string            // Default "curl"
+	Formatters  map[string]string // Mime type: Formatter command
+	Editor      string            // Default $EDITOR
+	ColorMode   bool              // TODO: implement - Default false, no color
+	InsecureSSL bool              // Default false
 }
 
 // ConfigFromReader constructs a Config from JSON data read from the Reader.

--- a/dothttp/dothttp.go
+++ b/dothttp/dothttp.go
@@ -136,8 +136,12 @@ func readHeaders(i int, lines []string) (int, map[string]string) {
 		if !hasHeaderValue(lines[i]) {
 			return i, hs
 		}
+
 		parts := strings.Split(lines[i], ":")
-		hs[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		val := strings.ToLower(strings.TrimSpace(parts[1]))
+
+		hs[key] = val
 	}
 
 	return i, hs


### PR DESCRIPTION
This PR makes it possible to add Formatters to the configuration file. Formatters is a mapping between a mime-type and its corresponding formatter command.

As an example, `jq` can be used to format JSON responses.

The request must have the accept-header defined to a configured mime-type.