### PR TITLE
Directory mode

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,21 +1,28 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/callerobertsson/resty/dothttp"
+	"github.com/callerobertsson/resty/utils"
 )
 
 type CLI struct {
 	config   *Config
 	httpFile string
+	rootDir  string
 	dotHTTP  *dothttp.DotHTTP
 	current  int
 }
 
-func New(f string, c *Config) *CLI {
-	return &CLI{config: c, httpFile: f}
+func New(c *Config) *CLI {
+	return &CLI{config: c}
 }
 
-func (cli *CLI) Start() error {
+func (cli *CLI) StartFile(f string) error {
+	cli.httpFile = f
+
 	maybeDH, err := dothttp.NewFromFile(cli.httpFile)
 	if err != nil {
 		return err
@@ -29,4 +36,34 @@ func (cli *CLI) Start() error {
 	}
 
 	return cli.commandLoop()
+}
+func (cli *CLI) StartDirectory(d string) error {
+	// Loop until quit
+	for {
+		// Find all .http-files recursively
+		httpFiles := utils.GetHttpFilePaths(d, true)
+		if len(httpFiles) < 1 {
+			fmt.Printf("No .http-files found in %v\n", d)
+			os.Exit(1)
+		}
+
+		title := "Resty File Selector\n(up, down to navigate, ctrl-c to exit)\n"
+		prompt := "fuzzy find file"
+		f, err := utils.FuzzyListPicker(title, prompt, httpFiles)
+		if err != nil {
+			return err
+		}
+
+		if f == "" {
+			fmt.Println("bye")
+			return nil
+		}
+
+		if err := cli.StartFile(f); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			continue
+		}
+
+		utils.RenderClear()
+	}
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,9 +1,6 @@
 package cli
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/callerobertsson/resty/dothttp"
 	"github.com/callerobertsson/resty/utils"
 )
@@ -21,6 +18,7 @@ func New(c *Config) *CLI {
 }
 
 func (cli *CLI) StartFile(f string) error {
+
 	cli.httpFile = f
 
 	maybeDH, err := dothttp.NewFromFile(cli.httpFile)
@@ -30,40 +28,21 @@ func (cli *CLI) StartFile(f string) error {
 
 	cli.dotHTTP = maybeDH
 
-	colorOff()
+	utils.ColorOff()
 	if cli.config.ColorMode {
-		colorOn()
+		utils.ColorOn()
 	}
 
 	return cli.commandLoop()
 }
+
 func (cli *CLI) StartDirectory(d string) error {
-	// Loop until quit
-	for {
-		// Find all .http-files recursively
-		httpFiles := utils.GetHttpFilePaths(d, true)
-		if len(httpFiles) < 1 {
-			fmt.Printf("No .http-files found in %v\n", d)
-			os.Exit(1)
-		}
 
-		title := "Resty File Selector\n(up, down to navigate, ctrl-c to exit)\n"
-		prompt := "fuzzy find file"
-		f, err := utils.FuzzyListPicker(title, prompt, httpFiles)
-		if err != nil {
-			return err
-		}
-
-		if f == "" {
-			fmt.Println("bye")
-			return nil
-		}
-
-		if err := cli.StartFile(f); err != nil {
-			fmt.Printf("Error: %v\n", err)
-			continue
-		}
-
-		utils.RenderClear()
+	utils.ColorOff()
+	if cli.config.ColorMode {
+		utils.ColorOn()
 	}
+
+	return cli.selectLoop(d)
+
 }

--- a/cli/commandloop.go
+++ b/cli/commandloop.go
@@ -17,7 +17,7 @@ func (cli *CLI) commandLoop() error {
 
 	// Command loop
 	for {
-		renderClear()
+		utils.RenderClear()
 
 		cli.renderHeader()
 		cli.renderUI()
@@ -28,8 +28,9 @@ func (cli *CLI) commandLoop() error {
 		r := rune(buf[0])
 
 		switch {
-		case r == 'q':
+		case r == 'q' || r == 27:
 			handleQuit()
+			return nil
 		case r == 'g':
 			cli.handleFirst()
 		case r == 'k' || r == 65:
@@ -55,7 +56,7 @@ func (cli *CLI) commandLoop() error {
 func handleQuit() {
 	fmt.Println("\nbye!")
 	utils.SetBufferedInput()
-	os.Exit(0)
+	// os.Exit(0)
 }
 
 func (cli *CLI) handleFirst() {
@@ -83,7 +84,7 @@ func (cli *CLI) handleLast() {
 func (cli *CLI) handleEdit() {
 	// Edit .http-file (until no errors)
 	for {
-		renderClear()
+		utils.RenderClear()
 		_, err := utils.EditFile(cli.httpFile, cli.config.Editor)
 		if err != nil {
 			stopMessage("Error editing %v: %v\n", cli.httpFile, err)
@@ -104,21 +105,21 @@ func (cli *CLI) handleEdit() {
 
 func (cli *CLI) handleConfig() {
 	// Config - show config file
-	renderClear()
+	utils.RenderClear()
 	cli.renderConfig()
 	stopMessage("\n")
 }
 
 func (cli *CLI) handleVariables() {
 	// Variables - show variables active for current request
-	renderClear()
+	utils.RenderClear()
 	cli.renderVariables()
 	stopMessage("\n")
 }
 
 func (cli *CLI) handleRun() {
 	// Run current request
-	renderClear()
+	utils.RenderClear()
 	// cli.renderRequestInfo()
 	err := cli.runCurrentRequest()
 	if err != nil {
@@ -128,7 +129,7 @@ func (cli *CLI) handleRun() {
 
 func handleHelp() {
 	// Show help
-	renderClear()
+	utils.RenderClear()
 	stopMessage("%v\n", keyHelpText)
 }
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -77,6 +77,7 @@ func ConfigJSON(c Config) string {
 // the empty string it tries to read the default config file. If that fails an
 // empty Config, with default values, are returned.
 func GetConfigOrDefault(f string) (*Config, error) {
+
 	// Default config
 	config := Config{
 		CurlCommand: "curl",

--- a/cli/render.go
+++ b/cli/render.go
@@ -4,25 +4,33 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/callerobertsson/resty/utils"
 )
 
 func (cli *CLI) renderHeader() {
+	fmt.Printf("%s", cli.headerString())
+}
+
+func (cli *CLI) headerString() string {
+
 	conf := ", conf: none"
 	if cli.config.configFile != "" {
 		conf = " - " + cli.config.configFile
 	}
-	fmt.Printf(TITLE+"RESTY "+SUBTITLE+"%s%s\n\n"+NORM, cli.httpFile, conf)
+
+	return fmt.Sprintf(utils.TITLE+"RESTY "+utils.SUBTITLE+"%s%s\n\n"+utils.NORM, cli.httpFile, conf)
 }
 
 func (cli *CLI) renderPrompt() {
-	fmt.Printf(SUBTITLE + "\n[revcq?] > " + NORM)
+	fmt.Printf(utils.SUBTITLE + "\n[revcq?] > " + utils.NORM)
 }
 
 func (cli *CLI) renderUI() {
 	for i, r := range cli.dotHTTP.Requests {
-		indicator := NORM + " "
+		indicator := utils.NORM + " "
 		if i == cli.current {
-			indicator = NOTICE + ">" + SELECTED
+			indicator = utils.NOTICE + ">" + utils.SELECTED
 		}
 
 		if r.Name == "" {
@@ -48,7 +56,7 @@ func (cli *CLI) renderUI() {
 
 func (cli *CLI) renderVariables() {
 	if len(cli.dotHTTP.Requests[cli.current].Variables) > 0 {
-		fmt.Printf(TITLE + "Variables:\n" + NORM)
+		fmt.Printf(utils.TITLE + "Variables:\n" + utils.NORM)
 		renderStringMap(cli.dotHTTP.Requests[cli.current].Variables, "  ")
 	} else {
 		fmt.Printf("No variables\n")
@@ -56,7 +64,7 @@ func (cli *CLI) renderVariables() {
 }
 
 func (cli *CLI) renderConfig() {
-	fmt.Printf(TITLE+"Config in %s:\n"+NORM, cli.config.configFile)
+	fmt.Printf(utils.TITLE+"Config in %s:\n"+utils.NORM, cli.config.configFile)
 	fmt.Printf("%s", ConfigJSON(*cli.config))
 }
 
@@ -68,7 +76,7 @@ func renderStringMap(vars map[string]string, indent string) {
 
 func confirmMessage(f string, a ...any) bool {
 	fmt.Printf(f, a...)
-	fmt.Printf(SELECTED + "-- press 'y' to continue --\n" + NORM)
+	fmt.Printf(utils.SELECTED + "-- press 'y' to continue --\n" + utils.NORM)
 	bs := make([]byte, 1)
 	_, _ = os.Stdin.Read(bs)
 
@@ -77,6 +85,6 @@ func confirmMessage(f string, a ...any) bool {
 
 func stopMessage(f string, a ...any) {
 	fmt.Printf(f, a...)
-	fmt.Printf(SELECTED + "-- press any key to continue --\n" + NORM)
+	fmt.Printf(utils.SELECTED + "-- press any key to continue --\n" + utils.NORM)
 	_, _ = os.Stdin.Read(make([]byte, 1))
 }

--- a/cli/render.go
+++ b/cli/render.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 )
 
@@ -66,19 +64,6 @@ func renderStringMap(vars map[string]string, indent string) {
 	for k, v := range vars {
 		fmt.Printf("%s%s = %q\n", indent, k, v)
 	}
-}
-
-func renderClear() {
-	if runtime.GOOS == "windows" {
-		cmd := exec.Command("cmd", "/c", "cls")
-		cmd.Stdout = os.Stdout
-		_ = cmd.Run()
-		return
-	}
-
-	cmd := exec.Command("clear")
-	cmd.Stdout = os.Stdout
-	_ = cmd.Run()
 }
 
 func confirmMessage(f string, a ...any) bool {

--- a/cli/runrequest.go
+++ b/cli/runrequest.go
@@ -13,7 +13,7 @@ func (cli *CLI) runCurrentRequest() error {
 	r := cli.dotHTTP.Requests[cli.current]
 	args := r.BuildCurlArgs(cli.config.InsecureSSL)
 
-	fmt.Printf(TITLE + "=== CURL ======================================================================\n" + NORM)
+	fmt.Println(TITLE + "=== CURL ======================================================================" + NORM)
 	fmt.Printf("%s %s\n", cli.config.CurlCommand, strings.Join(args, " "))
 
 	if r.Verb != "GET" && !confirmMessage("Are you sure?\n") {
@@ -40,7 +40,7 @@ func (cli *CLI) runCurrentRequest() error {
 		}
 	}
 
-	fmt.Printf(TITLE + "=== Response ==================================================================\n" + NORM)
+	fmt.Println(TITLE + "=== Response ==================================================================" + NORM)
 	fmt.Printf("%s\n", resp)
 
 	info := ""

--- a/cli/runrequest.go
+++ b/cli/runrequest.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 
 	"github.com/callerobertsson/resty/dothttp"
+	"github.com/callerobertsson/resty/utils"
 )
 
 func (cli *CLI) runCurrentRequest() error {
 	r := cli.dotHTTP.Requests[cli.current]
 	args := r.BuildCurlArgs(cli.config.InsecureSSL)
 
-	fmt.Println(TITLE + "=== CURL ======================================================================" + NORM)
+	fmt.Println(utils.TITLE + "=== CURL ======================================================================" + utils.NORM)
 	fmt.Printf("%s %s\n", cli.config.CurlCommand, strings.Join(args, " "))
 
 	if r.Verb != "GET" && !confirmMessage("Are you sure?\n") {
@@ -40,10 +41,11 @@ func (cli *CLI) runCurrentRequest() error {
 		}
 	}
 
-	fmt.Println(TITLE + "=== Response ==================================================================" + NORM)
+	fmt.Println(utils.TITLE + "=== Response ==================================================================" + utils.NORM)
 	fmt.Printf("%s\n", resp)
+	fmt.Println(utils.TITLE + "===============================================================================" + utils.NORM)
 
-	info := ""
+	info := ", raw"
 	if fmtCmd != "" && mimeType != "" {
 		info = fmt.Sprintf(", formatted %q using %q", mimeType, fmtCmd)
 	}

--- a/cli/selectloop.go
+++ b/cli/selectloop.go
@@ -1,0 +1,40 @@
+// Package cli file selection loop
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/callerobertsson/resty/utils"
+)
+
+func (cli *CLI) selectLoop(d string) error {
+
+	for {
+		httpFiles := utils.GetHttpFilePaths(d, true)
+		if len(httpFiles) < 1 {
+			fmt.Printf("No .http-files found in %v\n", d)
+			os.Exit(1)
+		}
+
+		title := cli.headerString()
+
+		prompt := "\nfuzzy"
+		f, err := utils.FuzzyListPicker(title, prompt, httpFiles)
+		if err != nil {
+			return err
+		}
+
+		if f == "" {
+			fmt.Println("bye")
+			return nil
+		}
+
+		if err := cli.StartFile(f); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			continue
+		}
+
+		utils.RenderClear()
+	}
+}

--- a/dothttp/dothttp.go
+++ b/dothttp/dothttp.go
@@ -169,6 +169,7 @@ func readBody(i int, lines []string) (int, string) {
 }
 
 func replaceVars(s string, vars map[string]string) string {
+	// {{var}}
 	r := s
 
 	for k, v := range vars {

--- a/dothttp/dothttp.go
+++ b/dothttp/dothttp.go
@@ -117,7 +117,7 @@ func (dotHTTP *DotHTTP) LoadHTTPFileLines(lines []string) error {
 				newNewI, body := readBody(i+1, lines)
 				i = newNewI + 1 // for-loop i++ adjustment
 
-				currRequest.Body = strings.TrimSpace(body)
+				currRequest.Body = replaceVars(strings.TrimSpace(body), vars)
 			}
 
 			rs = append(rs, currRequest) // store previous request
@@ -168,15 +168,15 @@ func readBody(i int, lines []string) (int, string) {
 	return i - 1, body
 }
 
-func replaceVars(urlFormat string, vars map[string]string) string {
-	url := urlFormat
+func replaceVars(s string, vars map[string]string) string {
+	r := s
 
 	for k, v := range vars {
 		k = strings.TrimLeft(k, "@")
-		url = strings.ReplaceAll(url, "{{"+k+"}}", v)
+		r = strings.ReplaceAll(r, "{{"+k+"}}", v)
 	}
 
-	return url
+	return r
 }
 
 func parseName(s string) string {

--- a/dothttp/request.go
+++ b/dothttp/request.go
@@ -26,12 +26,14 @@ func (r Request) BuildCurlArgs(insecureSSL bool) []string {
 
 	// Headers (-H)
 	for k, v := range r.Headers {
-		args = append(args, "-H '"+k+": "+v+"'")
+		args = append(args, "-H")
+		args = append(args, k+": "+v)
 	}
 
 	// Body (-d)
 	if r.Body != "" {
-		args = append(args, "-d '"+r.Body+"'")
+		args = append(args, "-d")
+		args = append(args, r.Body)
 	}
 
 	// // URL

--- a/example/config.json
+++ b/example/config.json
@@ -1,5 +1,6 @@
 {
-  "CurlCommand": "_dev/curl",
-  "Editor": "",
-  "ColorMode": false
+  "CurlCommand": "curl",
+  "Editor": "nvim",
+  "ColorMode": false,
+  "InsecureSSL": true
 }

--- a/example/example.http
+++ b/example/example.http
@@ -2,6 +2,44 @@
 #
 
 @place=Marks%20Kommun
+@gorest_url=https://gorest.co.in/public/v2
+
+### Dummy POST Test
+POST http://localhost:12345/echobody
+Content-Type: application/json
+Accept: application/json
+Authorization: Bearer ACCESS-TOKEN
+
+data
+
+
+
+
+
+###
+#
+#
+{
+    "name":"Inghe Brahe",
+    "korv":"spad"
+}
+
+### Users
+GET {{gorest_url}}
+
+### Create user
+POST {{gorest_url}}/users
+Content-Type: application/json
+Accept: application/json
+Authorization: Bearer ACCESS-TOKEN
+
+{
+    "name":"Tenali Ramakrishna",
+    "gender":"male",
+    "email":"tenali.ramakrishna@15ce.com",
+    "status":"active"
+}
+
 
 ### @name Weather
 GET wttr.in/{{place}}

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var (
 
 	// Command line flags parsed in parseCommandLine().
 	configFile     = ""
-	httpFile       = ""
+	path           = ""
 	showVersion    = false
 	generateConfig = false
 )
@@ -33,11 +33,27 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create CLI
-	cli := cli.New(httpFile, config)
+	if path == "" {
+		path = "."
+	}
 
-	if err = cli.Start(); err != nil {
-		fmt.Printf("Error running Resty: %v\n", err)
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		fmt.Printf("Path %q does not exist", path)
+		os.Exit(1)
+	}
+
+	switch {
+	case fi.IsDir():
+		if err = cli.New(config).StartDirectory(path); err != nil {
+			fmt.Printf("\nError: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		if err = cli.New(config).StartFile(path); err != nil {
+			fmt.Printf("\nError: %v", err)
+			os.Exit(1)
+		}
 	}
 }
 
@@ -62,13 +78,7 @@ func parseCommandLine() {
 	}
 
 	if len(flag.Args()) > 0 {
-		httpFile = flag.Args()[0]
-	}
-
-	if httpFile == "" {
-		fmt.Printf("Error: Need a .httpFile as argument\n")
-		fmt.Printf("Use -h for help\n")
-		os.Exit(1)
+		path = flag.Args()[0]
 	}
 }
 
@@ -78,13 +88,19 @@ func usage() {
 
 	fmt.Fprintf(out, `RESTY
     SYNOPSIS
-          resty [flags] <.http-file>
+          resty [options] [<.http-file>|<directory>]
 
     DESCRIPTON
-          Resty opens the <.http-file> and displays list of the requests.
-          The list can be navigated using vim-like bindings or arrow keys.
+          By default, resty will open in directory mod and list all .http-file in current directory
+          and below. The user can then select which one to open.
 
-          Requests can be run and the .http-file edited.
+          If there is an argument on the command line, resty will check if it is a directory and
+          open it in directory mode. If the argument is a file, resty will open it in file mode.
+
+          Resty opens <.http-file> and displays list of the requests. The list can be navigated
+          using vim-like bindings or arrow keys.
+
+          Requests can be run by pressing '<enter>' and the .http-file edited by pressing 'e'.
 
           For more info press '?' to show the available commands.
 

--- a/main.go
+++ b/main.go
@@ -102,6 +102,9 @@ func usage() {
 
           Requests can be run by pressing '<enter>' and the .http-file edited by pressing 'e'.
 
+          A default config file can be printed by using the '-g' flag. Modify it and put it in
+		  $HOME/.resty.json.
+
           For more info press '?' to show the available commands.
 
     OPTIONS

--- a/utils/color.go
+++ b/utils/color.go
@@ -1,5 +1,5 @@
-// Package cli color functions.
-package cli
+// Package utils color functions.
+package utils
 
 // Terminal color constants.
 var (
@@ -11,7 +11,7 @@ var (
 )
 
 // Turn colors on.
-func colorOn() {
+func ColorOn() {
 	NORM = "\033[0m"
 	TITLE = "\033[1;33m"    // title - yellow bold
 	SUBTITLE = "\033[37m"   // greyish
@@ -20,7 +20,7 @@ func colorOn() {
 }
 
 // Turn color off.
-func colorOff() {
+func ColorOff() {
 	NORM = ""
 	TITLE = ""    // title - yellow bold
 	SUBTITLE = "" // greyish

--- a/utils/file.go
+++ b/utils/file.go
@@ -3,9 +3,55 @@ package utils
 import (
 	"errors"
 	"os"
+	"regexp"
+	"strings"
 )
 
+var reHttpFile = regexp.MustCompile("\\.http$")
+
+// FileExists checks if file path f exists
 func FileExists(f string) bool {
 	_, err := os.Stat(f)
 	return !errors.Is(err, os.ErrNotExist)
+}
+
+// GetHttpFile returns file paths for all .http file in directory path d with a recursive option
+func GetHttpFilePaths(d string, recure bool) []string {
+	fs, _ := getMatchingFiles(d, reHttpFile, recure)
+	return fs
+}
+
+// Get matching entries in dir, and if recursive, all subdirs
+// Returns list of matches and the total count of files in tree
+func getMatchingFiles(dir string, r *regexp.Regexp, recursive bool) ([]string, int) {
+
+	fis, err := os.ReadDir(dir)
+	if err != nil {
+		return []string{}, 0
+	}
+
+	entries := []string{}
+	dirs := []string{}
+	total := 0
+
+	for _, fi := range fis {
+		if strings.Index(fi.Name(), ".") != 0 && fi.IsDir() {
+			dirs = append(dirs, dir+"/"+fi.Name())
+			continue
+		}
+		total++
+		if r.MatchString(fi.Name()) {
+			entries = append(entries, dir+"/"+fi.Name())
+		}
+	}
+
+	if recursive {
+		for _, d := range dirs {
+			newEntries, newTotal := getMatchingFiles(d, r, recursive)
+			total += newTotal
+			entries = append(entries, newEntries...)
+		}
+	}
+
+	return entries, total
 }

--- a/utils/picker.go
+++ b/utils/picker.go
@@ -33,14 +33,16 @@ func FuzzyListPicker(t, p string, ss []string) (string, error) {
 
 		for i, f := range fss {
 			marker := " "
+			col := NORM
 			if i == current {
-				marker = ">"
+				marker = NOTICE + ">" + NORM
+				col = SELECTED
 			}
 
-			fmt.Printf(" %s %v\n", marker, f)
+			fmt.Printf(" %s %s%v\n"+NORM, marker, col, f)
 		}
 
-		fmt.Printf("%s > %s", p, input)
+		fmt.Printf("%s > %s", SUBTITLE+p+NORM, SELECTED+input+NORM)
 
 		_, _ = os.Stdin.Read(buf)
 		r := rune(buf[0])

--- a/utils/picker.go
+++ b/utils/picker.go
@@ -1,0 +1,116 @@
+package utils
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// FuzzyListPicker lets the user search and navigate the strings in ss. It returns the
+// currently selected string on <enter>.
+func FuzzyListPicker(t, p string, ss []string) (string, error) {
+
+	SetUnbufferedInput()
+	defer SetBufferedInput()
+
+	input := ""
+	buf := make([]byte, 2)
+	fss := ss
+	current := 0
+
+	for {
+		if current >= len(fss) {
+			current = len(fss) - 1
+		}
+
+		RenderClear()
+
+		fmt.Printf("%s", t)
+
+		for i, f := range fss {
+			marker := " "
+			if i == current {
+				marker = ">"
+			}
+
+			fmt.Printf(" %s %v\n", marker, f)
+		}
+
+		fmt.Printf("%s > %s", p, input)
+
+		_, _ = os.Stdin.Read(buf)
+		r := rune(buf[0])
+
+		switch {
+		// TODO: Should add `?` for help
+		case r == 65: // up
+			current--
+			if current < 0 {
+				current = 0
+			}
+		case r == 66: // down
+			current++
+			if current >= len(fss) {
+				current = len(fss) - 1
+			}
+		case r == '\n': // enter
+			if len(fss) < 1 {
+				return "", errors.New("nothing selected")
+			}
+			return fss[current], nil
+		case r == '\x7f': // bksp
+			current = 0
+			fss = ss
+			if len(input) > 0 {
+				input = string(input[0 : len(input)-1])
+			}
+		case r == 27: // esc
+			// do nothing by design (up and down arrows are spooky)
+		default:
+			input = input + string(r)
+		}
+
+		fss = filter(fss, input)
+	}
+}
+
+func filter(ss []string, m string) []string {
+
+	re, err := regexp.Compile(strings.Join(strings.Split(strings.ToLower(m), ""), ".*"))
+	if err != nil {
+		return []string{}
+	}
+
+	ms := []string{}
+
+	for _, s := range ss {
+		if re.MatchString(strings.ToLower(s)) {
+			ms = append(ms, s)
+		}
+	}
+
+	return ms
+}
+
+func ListPicker(p string, ss []string) (int, string) {
+
+	for i, f := range ss {
+		fmt.Printf("%4d: %v\n", i+1, f)
+	}
+
+	fmt.Printf("%s > ", p)
+
+	r := bufio.NewReader(os.Stdin)
+	input, _, _ := r.ReadLine()
+
+	n, err := strconv.Atoi(string(input))
+	if err != nil || n < 1 || n > len(ss) {
+		return -1, ""
+	}
+
+	return n, ss[n-1]
+}

--- a/utils/render.go
+++ b/utils/render.go
@@ -1,0 +1,18 @@
+package utils
+
+import "fmt"
+
+func RenderClear() {
+	// TODO: Test if this works on both Linux and Win
+	fmt.Printf(string("\x1b[2J\x1b[H"))
+	// if runtime.GOOS == "windows" {
+	// 	cmd := exec.Command("cmd", "/c", "cls")
+	// 	cmd.Stdout = os.Stdout
+	// 	_ = cmd.Run()
+	// 	return
+	// }
+	//
+	// cmd := exec.Command("clear")
+	// cmd.Stdout = os.Stdout
+	// _ = cmd.Run()
+}


### PR DESCRIPTION
Resty can now be started with a directory as an argument and then will display all .http-file in the directory structure. Fuzzy find and arrow keys can be used to find the wanted .http-file. Press <enter> to open the file and ctrl-c to exit.

Also fixes curl-argument bug.
